### PR TITLE
Improve hint reveal and soften notebook palette

### DIFF
--- a/src/components/RestoreMission.jsx
+++ b/src/components/RestoreMission.jsx
@@ -123,9 +123,9 @@ function RestoreMission() {
 
   const getHintText = (word) => {
     const length = word.length;
-    return showHints 
-      ? `${getFirstLetter(word)}${'_'.repeat(length - 1)} (${length} 字母)`
-      : `${getFirstLetter(word)}__ (${length} 字母)`;
+    return showHints
+      ? `${word} (${length} 字母)`
+      : `${getFirstLetter(word)}${'_'.repeat(length - 1)} (${length} 字母)`;
   };
 
   if (!currentMission) {
@@ -210,12 +210,12 @@ function RestoreMission() {
   }
 
   return (
-    <div className={`relative bg-gradient-to-br from-indigo-600 via-purple-500 to-pink-400 text-white p-6 rounded-lg shadow-lg transition-all duration-300 ${sparkleAnimation ? 'animate-pulse' : ''} overflow-hidden`}>
+    <div className={`relative bg-white text-gray-800 p-6 border-2 border-indigo-200 rounded-lg shadow-lg transition-all duration-300 ${sparkleAnimation ? 'animate-pulse' : ''} overflow-hidden`}>
       <div className="absolute inset-0 pointer-events-none">
         {missionStars.map((star, i) => (
           <div
             key={i}
-            className="absolute w-1 h-1 bg-white rounded-full opacity-40 animate-pulse"
+            className="absolute w-1 h-1 bg-indigo-200 rounded-full opacity-70"
             style={{
               left: star.left,
               top: star.top,
@@ -239,7 +239,7 @@ function RestoreMission() {
       
       <div className="mb-6">
         <h3 className="text-xl mb-2">
-          主星詞: <span className="font-bold text-yellow-200">{currentMission.word}</span>
+          主星詞: <span className="font-bold text-indigo-600">{currentMission.word}</span>
         </h3>
         <p className="text-lg opacity-80 mb-2">
           意思: {currentMission.meaning}
@@ -254,7 +254,7 @@ function RestoreMission() {
           <h4 className="font-bold text-lg">請填入所有同義詞：</h4>
           <button
             onClick={() => setShowHints(!showHints)}
-            className="px-3 py-1 bg-yellow-300 bg-opacity-30 hover:bg-opacity-50 rounded-lg text-sm"
+            className="px-3 py-1 bg-indigo-100 hover:bg-indigo-200 rounded-lg text-sm"
           >
             {showHints ? '🙈 隱藏提示' : '💡 顯示提示'}
           </button>
@@ -263,7 +263,7 @@ function RestoreMission() {
         <div className="grid gap-3">
           {currentMission.synonyms.map((synonym, index) => (
             <div key={synonym} className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-white bg-opacity-20 rounded-full flex items-center justify-center text-sm font-bold">
+              <div className="w-8 h-8 bg-indigo-100 rounded-full flex items-center justify-center text-sm font-bold">
                 {index + 1}
               </div>
 
@@ -304,7 +304,7 @@ function RestoreMission() {
             <span>進度: {getCorrectCount()} / {currentMission.synonyms.length}</span>
             <span>完成度: {Math.round((getCorrectCount() / currentMission.synonyms.length) * 100)}%</span>
           </div>
-          <div className="w-full bg-white bg-opacity-20 rounded-full h-2 mt-2">
+          <div className="w-full bg-slate-200 rounded-full h-2 mt-2">
             <div
               className="bg-emerald-300 h-2 rounded-full transition-all duration-500"
               style={{ width: `${(getCorrectCount() / currentMission.synonyms.length) * 100}%` }}

--- a/src/components/StarNotebook.jsx
+++ b/src/components/StarNotebook.jsx
@@ -31,7 +31,7 @@ function StarNotebook() {
 
   if (markedWords.length === 0) {
     return (
-      <div className="bg-gradient-to-r from-amber-600 to-orange-600 text-white p-6 rounded-lg shadow-lg">
+      <div className="bg-gradient-to-r from-teal-100 to-blue-100 text-gray-800 p-6 rounded-lg shadow-lg">
         <h2 className="text-2xl font-bold mb-4">📖 星語冊</h2>
         <div className="text-center py-8">
           <div className="text-6xl mb-4">📝</div>
@@ -47,7 +47,7 @@ function StarNotebook() {
   }
 
   return (
-    <div className="bg-gradient-to-r from-amber-600 to-orange-600 text-white p-6 rounded-lg shadow-lg">
+    <div className="bg-gradient-to-r from-teal-100 to-blue-100 text-gray-800 p-6 rounded-lg shadow-lg">
       <div className="flex justify-between items-center mb-6">
         <h2 className="text-2xl font-bold">📖 星語冊</h2>
         <div className="text-sm opacity-80">
@@ -57,38 +57,38 @@ function StarNotebook() {
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {markedWordDetails.map((wordDetail) => {
-          const accuracyRate = wordDetail.attempts > 0 ? 
+          const accuracyRate = wordDetail.attempts > 0 ?
             (wordDetail.correct / wordDetail.attempts * 100) : 0;
-          
+
           return (
-            <div 
+            <div
               key={wordDetail.word}
-              className="bg-white bg-opacity-20 p-4 rounded-lg backdrop-blur-sm"
+              className="bg-white p-4 rounded-lg shadow"
             >
               <div className="flex justify-between items-start mb-2">
-                <h3 className="text-lg font-bold text-yellow-200">
+                <h3 className="text-lg font-bold text-indigo-700">
                   {wordDetail.word}
                 </h3>
                 <button
                   onClick={() => handleRemoveMark(wordDetail.word)}
-                  className="text-red-300 hover:text-red-100 text-sm"
+                  className="text-red-500 hover:text-red-400 text-sm"
                   title="移除標記"
                 >
                   ❌
                 </button>
               </div>
-              
+
               <p className="text-sm mb-3 opacity-90">
                 {wordDetail.meaning}
               </p>
-              
+
               <div className="mb-3">
                 <p className="text-xs opacity-70 mb-1">同義詞:</p>
                 <div className="flex flex-wrap gap-1">
                   {wordDetail.synonyms.slice(0, 4).map((synonym, index) => (
-                    <span 
+                    <span
                       key={index}
-                      className="bg-white bg-opacity-30 px-2 py-1 rounded text-xs"
+                      className="bg-indigo-50 px-2 py-1 rounded text-xs"
                     >
                       {synonym}
                     </span>
@@ -104,9 +104,9 @@ function StarNotebook() {
               <div className="flex justify-between items-center text-xs mb-3">
                 <div className="flex items-center gap-2">
                   <span>亮度:</span>
-                  <div className="w-16 h-2 bg-white bg-opacity-30 rounded-full overflow-hidden">
-                    <div 
-                      className="h-full bg-yellow-300 transition-all duration-300"
+                  <div className="w-16 h-2 bg-slate-200 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-indigo-300 transition-all duration-300"
                       style={{ width: `${wordDetail.brightness * 100}%` }}
                     />
                   </div>


### PR DESCRIPTION
## Summary
- Reveal full synonyms when hints are enabled and modernize the mission view with a clean white card bordered in indigo.
- Refresh Star Notebook with a calming teal/blue theme and lightweight cards for marked words.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68909a34d7a483229536ba5c87e07f13