### PR TITLE
Make star map connections dashed and centered

### DIFF
--- a/src/components/StarMap.jsx
+++ b/src/components/StarMap.jsx
@@ -297,10 +297,11 @@ function StarMap() {
                 stroke={connectionBrightness > 0 ? 'url(#magicalGradient)' : '#9ca3af'}
                 strokeWidth="2"
                 opacity={0.8 + connectionBrightness * 0.2}
+                strokeLinecap="round"
                 className="transition-all duration-500 drop-shadow-sm"
                 style={{
                   filter: `brightness(${0.8 + connectionBrightness * 0.5})`,
-                  strokeDasharray: 'none',
+                  strokeDasharray: '4 4',
                   animation: connectionBrightness > 0.3 ? 'twinkle 2s ease-in-out infinite' : 'none'
                 }}
               />
@@ -321,7 +322,7 @@ function StarMap() {
           return (
             <div
               key={star.word}
-              className={`absolute transform -translate-x-1/2 -translate-y-1/2 cursor-pointer transition-all duration-500 hover:scale-125 fade-in ${animationClass}`}
+              className={`absolute transform -translate-x-1/2 -translate-y-1/2 cursor-pointer transition-all duration-500 hover:scale-125 fade-in z-10 ${animationClass}`}
               style={{
                 left: `${position.x}%`,
                 top: `${position.y}%`,


### PR DESCRIPTION
## Summary
- Ensure star map connections render beneath stars so dashed lines don't hide nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ba5b6a648322833af590b2322444